### PR TITLE
Update Aspire

### DIFF
--- a/RedisPlayground.ApiService/RedisPlayground.ApiService.csproj
+++ b/RedisPlayground.ApiService/RedisPlayground.ApiService.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="9.3.1" />
-    <PackageReference Include="Aspire.StackExchange.Redis" Version="9.3.1" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="13.3.3" />
+    <PackageReference Include="Aspire.StackExchange.Redis" Version="13.3.3" />
   </ItemGroup>
 
 </Project>

--- a/RedisPlayground.AppHost/RedisPlayground.AppHost.csproj
+++ b/RedisPlayground.AppHost/RedisPlayground.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.1" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.3.3" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.3" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.3.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#### PR Classification
Dependency update to keep packages current and compatible.

#### PR Summary
This pull request updates Aspire and Redis-related NuGet package versions to 13.3.3 for improved compatibility and support.
- RedisPlayground.ApiService.csproj: Updated Aspire.StackExchange.Redis.DistributedCaching and Aspire.StackExchange.Redis package references to 13.3.3.
- RedisPlayground.AppHost.csproj: Updated Aspire.AppHost.Sdk, Aspire.Hosting.AppHost, and Aspire.Hosting.Redis package references to 13.3.3.
